### PR TITLE
Ironic: Add support for local boot upstream

### DIFF
--- a/elements/ironic-discoverd-ramdisk-instack/init.d/80-discovery-ironic
+++ b/elements/ironic-discoverd-ramdisk-instack/init.d/80-discovery-ironic
@@ -196,7 +196,7 @@ run_standard_detect() {
     DISK_SIZE=$(($disk_bytes/1024/1024/1024 - 1))
 
     NODE_DATA="{\"ipmi_address\":\"$BMC_ADDRESS\",\"local_gb\":$DISK_SIZE,\"memory_mb\":$RAM,\"cpus\":$CPUS,\"cpu_arch\":\"$CPU_ARCH\""
-    NODE_DATA="$NODE_DATA,\"interfaces\":$IFACES,\"boot_interface\":\"$BOOTIF\"}"
+    NODE_DATA="$NODE_DATA,\"interfaces\":$IFACES,\"boot_interface\":\"$BOOTIF\",\"capabilities\":\"boot_option:local\"}"
     echo Collected $NODE_DATA
 
     echo "$NODE_DATA" > /standard.json

--- a/scripts/instack-ironic-deployment
+++ b/scripts/instack-ironic-deployment
@@ -34,7 +34,7 @@ function show_options () {
     echo "      --delete-nodes      -- Delete all nodes."
     echo "      --config-tools-provision"
     echo "                          -- Run provision.sh for config-tools"
-    echo "      -x                  -- enable tracing"        
+    echo "      -x                  -- enable tracing"
     echo "      --help, -h          -- Print this help message."
     echo
     exit $1
@@ -209,7 +209,7 @@ function setup_flavors {
         "cpu_arch"="x86_64" \
         "baremetal:deploy_kernel_id"="$deploy_kernel_id" \
         "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id" \
-        "baremetal:localboot"="true" \
+        "capabilities:boot_option"="local" \
         "profile=control"
     nova flavor-show baremetal_control
 
@@ -218,7 +218,7 @@ function setup_flavors {
         "cpu_arch"="x86_64" \
         "baremetal:deploy_kernel_id"="$deploy_kernel_id" \
         "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id" \
-        "baremetal:localboot"="true" \
+        "capabilities:boot_option"="local" \
         "profile=compute"
     nova flavor-show baremetal_compute
 }

--- a/scripts/instack-prepare-for-overcloud
+++ b/scripts/instack-prepare-for-overcloud
@@ -57,7 +57,7 @@ nova flavor-key baremetal set \
     "cpu_arch"="x86_64" \
     "baremetal:deploy_kernel_id"="$deploy_kernel_id" \
     "baremetal:deploy_ramdisk_id"="$deploy_ramdisk_id" \
-    "baremetal:localboot"="true"
+    "capabilities:boot_option"="local"
 
 sudo cp -f "$IMAGE_PATH/$DISCOVERY_NAME.kernel" "$TFTP_ROOT/discovery.kernel"
 sudo cp -f "$IMAGE_PATH/$DISCOVERY_NAME.initramfs" "$TFTP_ROOT/discovery.ramdisk"


### PR DESCRIPTION
Now that local boot is supported upstream, this patch is updating the
scripts to support the upstream version of local boot.
