### PR TITLE
Fix rhos-release call

### DIFF
--- a/scripts/instack-setup-host-rhel7
+++ b/scripts/instack-setup-host-rhel7
@@ -30,11 +30,9 @@ fi
 sudo rpm -Uvh --force http://rhos-release.virt.bos.redhat.com/repos/rhos-release/rhos-release-latest.noarch.rpm
 export RUN_RHOS_RELEASE=${RUN_RHOS_RELEASE:-"1"}
 if [ "$RUN_RHOS_RELEASE" = "1" ]; then
-    sudo rhos-release 6 -d
+    sudo rhos-release 6
 fi
-# Ideally though, we don't want to end up with any RHOS packages installed, so
-# we disable the poodle repo.
-sudo yum-config-manager --disable rhelosp-6.0-poodle
+
 # We need openwsman-python from the optional repo
 sudo yum-config-manager --enable rhelosp-rhel-7-server-opt
 


### PR DESCRIPTION
Previously, the script called: 'rhos-release 6 -d'.  Due to a bug
in the rhos-release tool, both 'poodle' and 'puddle' were enabled.

The script then disabled the 'poodle' repository, leaving the
'puddle' repository enabled.  Since both repositories have a
complete set of packages, the functional equivalent is to simply
call rhos-release without -d in the first place.

Signed-off-by: Lon Hohberger lhh@redhat.com
